### PR TITLE
Add support for SQL Server 2017

### DIFF
--- a/install/load-assembly-2017.sql
+++ b/install/load-assembly-2017.sql
@@ -31,7 +31,6 @@ go
 
 
 -- Second, drop the assembly and remove trust if it already exists
-drop assembly RegexAssembly
 IF (SELECT COUNT(1) FROM sys.trusted_assemblies WHERE description like 'sql-server-regex%')=1
 BEGIN
 	declare @AssemblyHash varbinary(64);
@@ -49,6 +48,8 @@ EXEC sp_add_trusted_assembly
 declare @AssemblyLocation varchar(8000);
 
 set @AssemblyLocation = '--SET LOCATION HERE, e.g. C:\Install\sql-server-regex-2016.dll'
+
+drop assembly IF EXISTS RegexAssembly
 
 CREATE ASSEMBLY RegexAssembly  
 FROM  @AssemblyLocation

--- a/install/load-assembly-2017.sql
+++ b/install/load-assembly-2017.sql
@@ -1,0 +1,57 @@
+-- First, drop the functions if they already exist.
+if OBJECT_ID('dbo.RegexMatch') is not null
+begin
+	exec ('drop function dbo.RegexMatch');
+end
+go
+
+if OBJECT_ID('dbo.RegexGroupMatch') is not null
+begin
+	exec ('drop function dbo.RegexGroupMatch');
+end
+go
+
+if OBJECT_ID('dbo.RegexReplace') is not null
+begin
+	exec ('drop function dbo.RegexReplace');
+end
+go
+
+if OBJECT_ID('dbo.RegexMatches') is not null
+begin
+	exec ('drop function dbo.RegexMatches');
+end
+go
+
+if OBJECT_ID('dbo.RegexSplit') is not null
+begin
+	exec ('drop function dbo.RegexSplit');
+end
+go
+
+
+-- Second, drop the assembly and remove trust if it already exists
+drop assembly RegexAssembly
+IF (SELECT COUNT(1) FROM sys.trusted_assemblies WHERE description like 'sql-server-regex%')=1
+BEGIN
+	declare @AssemblyHash varbinary(64);
+	SELECT @AssemblyHash=hash from sys.trusted_assemblies where description like 'sql-server-regex%'
+	EXEC sp_drop_trusted_assembly @AssemblyHash;
+END
+go
+
+
+-- Third, finally, trust and create the assembly (sql-server-regex-2016.dll is compatible with SQL Server 2017)
+EXEC sp_add_trusted_assembly 
+	0x52A8DC6C31B95961455746731FEC5DC4E8BF7F8791A6854473BB4F9A9577AA2BC4376213EC4AD9C3ADB0A0A55CEACCEBB9A01D7AC5CCBACA054B0F14EF4212D1, 
+	N'sql-server-regex, version=1.0.6494.17073';
+
+declare @AssemblyLocation varchar(8000);
+
+set @AssemblyLocation = '--SET LOCATION HERE, e.g. C:\Install\sql-server-regex-2016.dll'
+
+CREATE ASSEMBLY RegexAssembly  
+FROM  @AssemblyLocation
+WITH PERMISSION_SET = SAFE;  
+
+-- see https://msdn.microsoft.com/en-us/library/ms189524.aspx for details

--- a/install/sql-2005.md
+++ b/install/sql-2005.md
@@ -17,7 +17,7 @@ To install sql-server-regex, you need to:
 You need to [enable CLR on SQL Server](https://msdn.microsoft.com/en-us/library/ms131048.aspx) before you do anything else.
 
 ```
-exec sp_configure, 'clr enabled', 1
+exec sp_configure 'clr enabled', 1
 go
 reconfigure
 go

--- a/install/sql-2008.md
+++ b/install/sql-2008.md
@@ -17,7 +17,7 @@ To install sql-server-regex, you need to:
 You need to [enable CLR on SQL Server](https://msdn.microsoft.com/en-us/library/ms131048.aspx) before you do anything else.
 
 ```
-exec sp_configure, 'clr enabled', 1
+exec sp_configure 'clr enabled', 1
 go
 reconfigure
 go

--- a/install/sql-2012.md
+++ b/install/sql-2012.md
@@ -17,7 +17,7 @@ To install sql-server-regex, you need to:
 You need to [enable CLR on SQL Server](https://msdn.microsoft.com/en-us/library/ms131048.aspx) before you do anything else.
 
 ```
-exec sp_configure, 'clr enabled', 1
+exec sp_configure 'clr enabled', 1
 go
 reconfigure
 go

--- a/install/sql-2014.md
+++ b/install/sql-2014.md
@@ -17,7 +17,7 @@ To install sql-server-regex, you need to:
 You need to [enable CLR on SQL Server](https://msdn.microsoft.com/en-us/library/ms131048.aspx) before you do anything else.
 
 ```
-exec sp_configure, 'clr enabled', 1
+exec sp_configure 'clr enabled', 1
 go
 reconfigure
 go

--- a/install/sql-2016.md
+++ b/install/sql-2016.md
@@ -17,7 +17,7 @@ To install sql-server-regex, you need to:
 You need to [enable CLR on SQL Server](https://msdn.microsoft.com/en-us/library/ms131048.aspx) before you do anything else.
 
 ```
-exec sp_configure, 'clr enabled', 1
+exec sp_configure 'clr enabled', 1
 go
 reconfigure
 go

--- a/install/sql-2017.md
+++ b/install/sql-2017.md
@@ -1,0 +1,41 @@
+# Install onto SQL Server 2017
+
+![SQL Regex Logo](/images/sql-regex-logo.png)
+
+To install sql-server-regex, you need to:
+
+1. Download or fork this code. 
+2. Enable CLR
+3. Install the sql-server-regex assembly
+4. Create the T-SQL functions
+
+*Note*: this requires sysadmin privileges on your SQL Server instance.
+
+
+### Enable CLR
+
+You need to [enable CLR on SQL Server](https://msdn.microsoft.com/en-us/library/ms131048.aspx) before you do anything else.
+
+```
+exec sp_configure 'clr enabled', 1
+go
+reconfigure
+go
+```
+
+### Install the Assembly
+
+1. Download [load-assembly.sql](/install/load-assembly.sql). 
+2. Download the [sql-server-regex 2016 DLL](/install/dll/sql-server-regex-2016.dll).
+3. Copy both to the server you want to install sql-server-regex onto.
+4. Open load-assembly.sql, and set the value of @AssemblyLocation to the location of the sql-server-regex-2016.dll.
+5. Run the script.
+
+*Note*: if you want to compile the assembly yourself from code, go ahead. Make sure your target platform is the version of SQL Server you want (e.g. SQL Server 2016), and that you copy the DLL that's created to the install location in step 3, above.
+
+### Create the T-SQL Functions
+
+The final step is to create the scalar and table-valued functions that you can query using T-SQL. 
+
+1. Run [scalar-functions.sql](/install/scalar-functions.sql)
+2. Run [table-valued-functions.sql](/install/table-valued-functions.sql)

--- a/install/sql-2017.md
+++ b/install/sql-2017.md
@@ -25,7 +25,7 @@ go
 
 ### Install the Assembly
 
-1. Download [load-assembly.sql](/install/load-assembly.sql). 
+1. Download [load-assembly.sql](/install/load-assembly-2017.sql). 
 2. Download the [sql-server-regex 2016 DLL](/install/dll/sql-server-regex-2016.dll).
 3. Copy both to the server you want to install sql-server-regex onto.
 4. Open load-assembly.sql, and set the value of @AssemblyLocation to the location of the sql-server-regex-2016.dll.


### PR DESCRIPTION
SQL Server 2017 introduced assembly trust configuration. This pull requests intends to support systemic (re-)configuration of a SQL Server 2017 instance to trust the 'sql-server-regex' assembly.
A typo on sp_configure configuraiton instruction was also fixed.
Can you confirm if there is a real need to have a dedicated assembly for sql server 2017 since the one of sql server 2016 seems to work fine?